### PR TITLE
fix(eslint-rules): limit scope of angular/event-emitter-has-output

### DIFF
--- a/apps/angular-demo/src/app/app.component.ts
+++ b/apps/angular-demo/src/app/app.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  HostListener,
-  Input,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, HostListener, Output } from '@angular/core';
 
 @Component({
   selector: 'bitovi-root',

--- a/tools/eslint-rules/rules/angular/event-emitter-has-output.spec.ts
+++ b/tools/eslint-rules/rules/angular/event-emitter-has-output.spec.ts
@@ -22,10 +22,26 @@ ruleTester.run(RULE_NAME, rule, {
         @Output() complete!: EventEmitter;
       }`,
     },
+    {
+      code: `
+      @Directive()
+      class MyComponent {
+        @Output() complete!: EventEmitter;
+      }`,
+    },
+    // Okay since it doesn't have a Component or Directive decorator
+    {
+      code: `
+      class MyUndecoratedComponent {
+        @Input() event = new EventEmitter();
+      }
+      `,
+    },
   ],
   invalid: [
     {
       code: `
+      @Directive()
       class MyComponent {
         @Input() myInput: EventEmitter<MyEvent>;
       }`,
@@ -33,6 +49,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
+      @Component()
       class MyComponent {
         myProperty: EventEmitter;
       }`,
@@ -40,6 +57,7 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: `
+      @Component()
       class MyComponent {
         myProperty = new EventEmitter();
       }`,

--- a/tools/eslint-rules/rules/angular/event-emitter-has-output.ts
+++ b/tools/eslint-rules/rules/angular/event-emitter-has-output.ts
@@ -66,6 +66,24 @@ export const rule = createRule({
       [AST_NODE_TYPES.PropertyDefinition]: function (
         node: TSESTree.PropertyDefinition
       ) {
+        // Check if owning class is a Component or a Directive
+        const classDeclaration = node.parent?.parent;
+        if (classDeclaration?.type === AST_NODE_TYPES.ClassDeclaration) {
+          if (
+            !(classDeclaration.decorators ?? []).find((d) =>
+              checkDecoratorName(d, 'Component')
+            ) &&
+            !(classDeclaration.decorators ?? []).find((d) =>
+              checkDecoratorName(d, 'Directive')
+            )
+          ) {
+            // Doesn't have a @Component or @Directive decorator, so skip
+            return;
+          }
+        } else {
+          // Not in a class, so skip (This shouln't be possible)
+          return;
+        }
         const decorators = node.decorators ?? [];
         if (
           !decorators.find((decorator) =>


### PR DESCRIPTION
[Jira AOS2-50](https://bitovi.atlassian.net/browse/AOS2-50?atlOrigin=eyJpIjoiYTlkZjRmMGUxNmY4NGUyYjlhYTkwZDgwMWUzODk3M2EiLCJwIjoiaiJ9)

- Limit application of `angular/event-emitter-has-output` to property definitions contained within classes decorated by either `@Component` or `@Directive`