### PR TITLE
feat(nx-glue): replace nx local eslint solution with bitovi solution

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
   "ignorePatterns": ["**/*"],
-  "plugins": ["@nrwl/nx"],
+  "plugins": ["@nrwl/nx", "@bitovi/nx-glue"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/apps/angular-demo/.eslintrc.json
+++ b/apps/angular-demo/.eslintrc.json
@@ -5,14 +5,14 @@
     {
       "files": ["*.ts"],
       "rules": {
-        "@nrwl/nx/workspace/angular/host-listener-mouse-events-have-key-events": "error",
-        "@nrwl/nx/workspace/angular/host-listener-click-events-have-key-events": "error",
-        "@nrwl/nx/workspace/angular/no-rxjs-internal-import": "error",
-        "@nrwl/nx/workspace/angular/no-entry-components": "error",
-        "@nrwl/nx/workspace/angular/seo-friendly-route-path": "error",
-        "@nrwl/nx/workspace/angular/on-changes-use-input-bind": "error",
-        "@nrwl/nx/workspace/angular/event-emitter-has-output": "warn",
-        "@nrwl/nx/workspace/angular/no-input-readonly": "error",
+        "@bitovi/nx-glue/bitovi/angular/host-listener-mouse-events-have-key-events": "error",
+        "@bitovi/nx-glue/bitovi/angular/host-listener-click-events-have-key-events": "error",
+        "@bitovi/nx-glue/bitovi/angular/no-rxjs-internal-import": "error",
+        "@bitovi/nx-glue/bitovi/angular/no-entry-components": "error",
+        "@bitovi/nx-glue/bitovi/angular/seo-friendly-route-path": "error",
+        "@bitovi/nx-glue/bitovi/angular/on-changes-use-input-bind": "error",
+        "@bitovi/nx-glue/bitovi/angular/event-emitter-has-output": "warn",
+        "@bitovi/nx-glue/bitovi/angular/no-input-readonly": "error",
         "@angular-eslint/directive-selector": [
           "error",
           {

--- a/eslint-plugin-glue.config.js
+++ b/eslint-plugin-glue.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  bitovi: {
+    dir: 'tools/eslint-rules',
+    tsconfig: 'tsconfig.json',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@angular/cli": "~15.1.0",
         "@angular/compiler-cli": "~15.1.0",
         "@angular/language-service": "~15.1.0",
+        "@bitovi/eslint-plugin-nx-glue": "^1.0.0",
         "@nrwl/cypress": "15.6.3",
         "@nrwl/eslint-plugin-nx": "15.6.3",
         "@nrwl/jest": "15.6.3",
@@ -2963,6 +2964,15 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "node_modules/@bitovi/eslint-plugin-nx-glue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bitovi/eslint-plugin-nx-glue/-/eslint-plugin-nx-glue-1.0.0.tgz",
+      "integrity": "sha512-OcteIZQktIzlcI0eFe87fKuVIMJKPgengx2Q/26SQBQyowZZsbcFYoj11NjEXz1NU4cTmelahVi5u2f7EJ6/Qw==",
+      "dev": true,
+      "peerDependencies": {
+        "nx": "~15"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -20740,6 +20750,13 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "@bitovi/eslint-plugin-nx-glue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bitovi/eslint-plugin-nx-glue/-/eslint-plugin-nx-glue-1.0.0.tgz",
+      "integrity": "sha512-OcteIZQktIzlcI0eFe87fKuVIMJKPgengx2Q/26SQBQyowZZsbcFYoj11NjEXz1NU4cTmelahVi5u2f7EJ6/Qw==",
+      "dev": true,
+      "requires": {}
     },
     "@colors/colors": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@angular/cli": "~15.1.0",
     "@angular/compiler-cli": "~15.1.0",
     "@angular/language-service": "~15.1.0",
+    "@bitovi/eslint-plugin-nx-glue": "^1.0.0",
     "@nrwl/cypress": "15.6.3",
     "@nrwl/eslint-plugin-nx": "15.6.3",
     "@nrwl/jest": "15.6.3",


### PR DESCRIPTION
### Description

Replaced existing code to support nx's local eslint plugin support with [bitovi's eslint-plugin-nx-glue](https://github.com/bitovi/eslint-plugin-nx-glue).

Moving forward, this will give us more flexibility to migrate eslint plugins to libs or publish separate plugins without having to keep everything together and use the same package.json / tsconfig.json.